### PR TITLE
Updated docker scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,28 @@
 FROM maven
 
-ENV APP_NAME="openlrs" \
-    REPO_URL="https://github.com/e-ucm/OpenLRS" \
+ENV REPO_URL="https://github.com/e-ucm/OpenLRS" \
     REPO_TAG="master" \
     USER_NAME="user" \
     WORK_DIR="/app"
 
-# setup user & group
-RUN groupadd -r "$USER_NAME" \
-    && useradd -r -g "$USER_NAME" "$USER_NAME"
-
-# retrieve sources & setup workdir
-RUN mkdir ${WORK_DIR} \
-    && git clone -b "$REPO_TAG" --single-branch ${REPO_URL} ${WORK_DIR}
+# setup user, group and workdir
+RUN groupadd -r ${USER_NAME} \
+    && useradd -r -d ${WORK_DIR} -g ${USER_NAME} ${USER_NAME} \
+    && mkdir ${WORK_DIR} \
+    && chown ${USER_NAME}:${USER_NAME} ${WORK_DIR}
+USER ${USER_NAME}
+ENV HOME=${WORK_DIR}
 WORKDIR ${WORK_DIR}
+
+# retrieve sources
+RUN git clone -b "$REPO_TAG" --single-branch "$REPO_URL" .
 
 # get dependencies sorted out
 # running tests would require Redis, ElasticSearch up and running
-RUN mvn -Dmaven.test.skip=true compile
+RUN mvn -Dmaven.test.skip=true package
 
-# run (may lookup env. variables to make links work)
+# expose & run (may lookup env. variables to make links work)
 EXPOSE 8080
 CMD [ "./run.sh" ]
 
-# EXPECTS: Mongo at 27017, Redis at 6379 (see run.sh)
+# EXPECTS: ElasticSearch at 9300, Redis at 6379 (see run.sh)

--- a/run.sh
+++ b/run.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
 
-# see docker-compose run <container> env to see all
+# OpenLRS relies on Redis and ElasticSearch
+#   This script, intended to be run from within docker compose, tells 
+#   OpenLRS where to find each of those servers
 
+# expects something like REDIS_PORT_6379_TCP_ADDR=172.17.0.6
 R_PROPFILE=./src/main/resources/application-redis.properties
-R_HOST=${REDIS_PORT/*\//}
-R_HOST=${R_HOST/:*/}
+R_HOST=${REDIS_PORT_6379_TCP_ADDR}
 
+# expects something like ELASTIC_PORT_9300_TCP=tcp://172.17.0.5:9300
+#   and strips out the tcp:// from the start
+#   note that ELASTIC_PORT=tcp://172.17.0.5:9200 refers to the REST interface
+#   the native transport protocol goes over 9300
 E_PROPFILE=./src/main/resources/application-elasticsearch.properties
-E_HOST=${ELASTIC_PORT/*\//}
+E_HOST=${ELASTIC_PORT_9300_TCP/*\//}
 
 echo "Redis should be at: $R_HOST"
 echo "spring.redis.host=${R_HOST}" >> ${R_PROPFILE}


### PR DESCRIPTION
run.sh - better documentation, exposes the 9300 instead of the 9200
Dockerfile - runs unpriviledged build, avoids 1 extra subdir
